### PR TITLE
Support setting a custom prefix to be used at runtime

### DIFF
--- a/syntax-config.pri
+++ b/syntax-config.pri
@@ -7,11 +7,15 @@ win32|macx {
         DEFINES += GTKSOURCEVIEW_LANGUAGE_PATH=\\\"/usr/share/gtksourceview-3.0/language-specs/\\\"
         message(Using GtkSourceView language specifications.)
     }
+    
+    DATA_INSTALL_PREFIX = $$LIRI_INSTALL_DATADIR/liri-text
+    isEmpty(DATA_RUNTIME_PREFIX) {
+        DEFINES += ABSOLUTE_LANGUAGE_PATH=\\\"$$DATA_INSTALL_PREFIX/language-specs/\\\"
+    } else {
+        DEFINES += ABSOLUTE_LANGUAGE_PATH=\\\"$$DATA_RUNTIME_PREFIX/language-specs/\\\"
+    }
 
-    DATA_PREFIX = $$LIRI_INSTALL_DATADIR/liri-text
-    DEFINES += ABSOLUTE_LANGUAGE_PATH=\\\"$$DATA_PREFIX/language-specs/\\\"
-
-    syntax.path = $$DATA_PREFIX/language-specs
+    syntax.path = $$DATA_INSTALL_PREFIX/language-specs
     syntax.files = data/language-specs/*.lang
     INSTALLS += syntax
 } else {


### PR DESCRIPTION
To allow the Liri Text snap application to read the bundled
language specs at runtime, we need to be able to set
different paths for compile time and runtime.
This would be a possible implementation, let me know
if you'd like this to be done differently:
Support `CUSTOM_RUNTIME_DATADIR` and use it for
`ABSOLUTE_LANGUAGE_PATH`.
Rename `DATA_PREFIX` to `DATA_INSTALL_PREFIX` to clarify.