### PR TITLE
Improve handling of languages database

### DIFF
--- a/src/languagedatabasemaintainer.h
+++ b/src/languagedatabasemaintainer.h
@@ -28,20 +28,20 @@ class LanguageDatabaseMaintainer : public QObject
 {
     Q_OBJECT
 public:
-    explicit LanguageDatabaseMaintainer(const QString &connId, QObject *parent = nullptr);
+    explicit LanguageDatabaseMaintainer(const QString &path, QObject *parent = nullptr);
     ~LanguageDatabaseMaintainer();
 
 signals:
     void dbUpdated();
 protected:
-    void initDB();
+    void initDB(const QString &path);
 public slots:
     void init();
     void updateDB();
 private:
     QStringList specsDirs;
     QFileSystemWatcher *watcher;
-    QString m_connId;
+    QString m_connId, m_dbPath;
 };
 
 #endif // LANGUAGEDATABASEMAINTAINER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,8 @@ int main(int argc, char *argv[])
 
     QQmlApplicationEngine engine;
 
-    qmlRegisterSingletonType<HistoryManager>("io.liri.text", 1, 0, "History", reinterpret_cast<QObject *(*)(QQmlEngine*, QJSEngine*)>(HistoryManager::getInstance));
+    qmlRegisterSingletonType<HistoryManager>("io.liri.text", 1, 0, "History",
+                                             [](QQmlEngine*, QJSEngine*) -> QObject* { return HistoryManager::getInstance(); });
 
     engine.rootContext()->setContextProperty(QStringLiteral("newDoc"), nf);
     if(args.length() > 0)

--- a/src/src.qbs
+++ b/src/src.qbs
@@ -23,7 +23,8 @@ QtGuiApplication {
     cpp.defines: {
         var defines = base.concat([
             "TEXT_VERSION=" + project.version,
-            'USER_LANGUAGE_PATH="/language-specs/"'
+            'USER_LANGUAGE_PATH="/language-specs/"',
+            "LANGUAGE_DB_VERSION=1"
         ]);
         if (qbs.targetOS.contains("windows"))
             defines.push('RELATIVE_LANGUAGE_PATH="/language-specs/"');


### PR DESCRIPTION
This PR fixes two problems with database handling:
 - Database's been being used from two threads with a single connection which Qt SQL does not allow. Now LanguageDatabaseMaintainer opens it's own connection after being moved to a separate thread.
 - Every trigger of updateDB (including application startup) caused reading metadata of every language specification file. Now the database includes file modification times which allows to skip processing of unchanged files.